### PR TITLE
Removed untypedcache 19

### DIFF
--- a/src/Cache.cs
+++ b/src/Cache.cs
@@ -8,17 +8,30 @@ using Org.Infinispan.Query.Remote.Client;
 namespace Infinispan.Hotrod.Core
 {
 
-    public class UntypedCache
+    public interface UntypedCache
     {
-        public static UntypedCache NullCache = new UntypedCache(null, "");
-        protected InfinispanDG Cluster;
         public string Name { get; }
         public byte[] NameAsBytes { get; }
-        public byte Version { get; protected set; }
+        public byte Version { get; set; }
         public Int64 MessageId { get; }
         public byte ClientIntelligence { get; }
         public UInt32 TopologyId { get; set; }
-        public bool ForceReturnValue;
+        public Int32 Flags { get; }
+        public bool ForceReturnValue { get; set; }
+        public MediaType KeyMediaType { get; set; }
+        public MediaType ValueMediaType { get; set; }
+
+    }
+    public class Cache<K, V> : UntypedCache
+    {
+        protected InfinispanDG Cluster;
+        public string Name { get; }
+        public byte[] NameAsBytes { get; }
+        public byte Version { get; set; }
+        public Int64 MessageId { get; }
+        public byte ClientIntelligence { get; }
+        public UInt32 TopologyId { get; set; }
+        public bool ForceReturnValue { get; set; }
         public bool UseCacheDefaultLifespan;
         public bool UseCacheDefaultMaxIdle;
 
@@ -36,7 +49,7 @@ namespace Infinispan.Hotrod.Core
         public MediaType KeyMediaType { get; set; }
         public MediaType ValueMediaType { get; set; }
         public Codec30 codec;
-        public UntypedCache(InfinispanDG ispnCluster, string name)
+        public Cache(InfinispanDG ispnCluster, Marshaller<K> keyM, Marshaller<V> valM, string name)
         {
             Cluster = ispnCluster;
             Name = name;
@@ -50,13 +63,8 @@ namespace Infinispan.Hotrod.Core
                 ForceReturnValue = Cluster.ForceReturnValue;
             }
             codec = Codec.getCodec(Version);
-        }
 
-    }
-    public class Cache<K, V> : UntypedCache
-    {
-        public Cache(InfinispanDG ispnCluster, Marshaller<K> keyM, Marshaller<V> valM, string name) : base(ispnCluster, name)
-        {
+
             KeyMarshaller = keyM;
             ValueMarshaller = valM;
             Version = ispnCluster.Version;

--- a/src/Cache.cs
+++ b/src/Cache.cs
@@ -8,7 +8,7 @@ using Org.Infinispan.Query.Remote.Client;
 namespace Infinispan.Hotrod.Core
 {
 
-    public interface UntypedCache
+    public interface ICache
     {
         public string Name { get; }
         public byte[] NameAsBytes { get; }
@@ -22,7 +22,7 @@ namespace Infinispan.Hotrod.Core
         public MediaType ValueMediaType { get; set; }
 
     }
-    public class Cache<K, V> : UntypedCache
+    public class Cache<K, V> : ICache
     {
         protected InfinispanDG Cluster;
         public string Name { get; }
@@ -74,15 +74,15 @@ namespace Infinispan.Hotrod.Core
 
         public async Task<V> Get(K key)
         {
-            return await Cluster.Get(KeyMarshaller, ValueMarshaller, (UntypedCache)this, key);
+            return await Cluster.Get(KeyMarshaller, ValueMarshaller, (ICache)this, key);
         }
         public async Task<ValueWithVersion<V>> GetWithVersion(K key)
         {
-            return await Cluster.GetWithVersion(KeyMarshaller, ValueMarshaller, (UntypedCache)this, key);
+            return await Cluster.GetWithVersion(KeyMarshaller, ValueMarshaller, (ICache)this, key);
         }
         public async Task<ValueWithMetadata<V>> GetWithMetadata(K key)
         {
-            return await Cluster.GetWithMetadata(KeyMarshaller, ValueMarshaller, (UntypedCache)this, key);
+            return await Cluster.GetWithMetadata(KeyMarshaller, ValueMarshaller, (ICache)this, key);
         }
 
         public async Task<V> Put(K key, V value, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
@@ -95,11 +95,11 @@ namespace Infinispan.Hotrod.Core
         }
         public async Task<Boolean> ContainsKey(K key)
         {
-            return await Cluster.ContainsKey(KeyMarshaller, (UntypedCache)this, key);
+            return await Cluster.ContainsKey(KeyMarshaller, (ICache)this, key);
         }
         public async Task<(V PrevValue, Boolean Removed)> Remove(K key)
         {
-            return await Cluster.Remove(KeyMarshaller, ValueMarshaller, (UntypedCache)this, key);
+            return await Cluster.Remove(KeyMarshaller, ValueMarshaller, (ICache)this, key);
         }
         public async Task Clear()
         {
@@ -119,21 +119,21 @@ namespace Infinispan.Hotrod.Core
         }
         public async Task<Boolean> ReplaceWithVersion(K key, V value, Int64 version, ExpirationTime lifeSpan = null, ExpirationTime maxIdle = null)
         {
-            return await Cluster.ReplaceWithVersion(KeyMarshaller, ValueMarshaller, (UntypedCache)this, key, value, version, lifeSpan, maxIdle);
+            return await Cluster.ReplaceWithVersion(KeyMarshaller, ValueMarshaller, (ICache)this, key, value, version, lifeSpan, maxIdle);
         }
         public async Task<(V V, Boolean Removed)> RemoveWithVersion(K key, Int64 version)
         {
-            return await Cluster.RemoveWithVersion(KeyMarshaller, ValueMarshaller, (UntypedCache)this, key, version);
+            return await Cluster.RemoveWithVersion(KeyMarshaller, ValueMarshaller, (ICache)this, key, version);
         }
         public async Task<QueryResponse> Query(QueryRequest query)
         {
-            return await Cluster.Query(query, (UntypedCache)this);
+            return await Cluster.Query(query, (ICache)this);
         }
         public async Task<List<Object>> Query(String query)
         {
             var qr = new QueryRequest();
             qr.QueryString = query;
-            var queryResponse = await Cluster.Query(qr, (UntypedCache)this);
+            var queryResponse = await Cluster.Query(qr, (ICache)this);
             List<Object> result = new List<Object>();
             if (queryResponse.ProjectionSize > 0)
             {  // Query has select
@@ -153,7 +153,7 @@ namespace Infinispan.Hotrod.Core
         }
         public async Task<ISet<K>> KeySet()
         {
-            return await Cluster.KeySet<K>(KeyMarshaller, (UntypedCache)this);
+            return await Cluster.KeySet<K>(KeyMarshaller, (ICache)this);
         }
         private static List<Object> unwrapWithProjection(QueryResponse resp)
         {

--- a/src/InfinispanDG.cs
+++ b/src/InfinispanDG.cs
@@ -128,7 +128,7 @@ namespace Infinispan.Hotrod.Core
                 Console.WriteLine(message);
             }
         }
-        internal async ValueTask<V> Put<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key, V value, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
+        internal async ValueTask<V> Put<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key, V value, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
         {
             Commands.PUT<K, V> cmd = new Commands.PUT<K, V>(km, vm, key, value);
             cmd.Flags = cache.Flags;
@@ -145,7 +145,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.PrevValue;
         }
-        internal async ValueTask<V> Get<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key)
+        internal async ValueTask<V> Get<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key)
         {
             Commands.GET<K, V> cmd = new Commands.GET<K, V>(km, vm, key);
             cmd.Flags = cache.Flags;
@@ -154,7 +154,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.Value;
         }
-        internal async ValueTask<ValueWithVersion<V>> GetWithVersion<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key)
+        internal async ValueTask<ValueWithVersion<V>> GetWithVersion<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key)
         {
             Commands.GETWITHVERSION<K, V> cmd = new Commands.GETWITHVERSION<K, V>(km, vm, key);
             cmd.Flags = cache.Flags;
@@ -163,7 +163,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.ValueWithVersion;
         }
-        internal async ValueTask<ValueWithMetadata<V>> GetWithMetadata<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key)
+        internal async ValueTask<ValueWithMetadata<V>> GetWithMetadata<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key)
         {
             Commands.GETWITHMETADATA<K, V> cmd = new Commands.GETWITHMETADATA<K, V>(km, vm, key);
             cmd.Flags = cache.Flags;
@@ -172,7 +172,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.ValueWithMetadata;
         }
-        internal async ValueTask<Int32> Size(UntypedCache cache)
+        internal async ValueTask<Int32> Size(ICache cache)
         {
             Commands.SIZE cmd = new Commands.SIZE();
             cmd.Flags = cache.Flags;
@@ -181,7 +181,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.Size;
         }
-        internal async ValueTask<Boolean> ContainsKey<K>(Marshaller<K> km, UntypedCache cache, K key)
+        internal async ValueTask<Boolean> ContainsKey<K>(Marshaller<K> km, ICache cache, K key)
         {
             Commands.CONTAINSKEY<K> cmd = new Commands.CONTAINSKEY<K>(km, key);
             if (cache != null)
@@ -193,7 +193,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.IsContained;
         }
-        internal async ValueTask<(V V, Boolean Removed)> Remove<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key)
+        internal async ValueTask<(V V, Boolean Removed)> Remove<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key)
         {
             Commands.REMOVE<K, V> cmd = new Commands.REMOVE<K, V>(km, vm, key);
             cmd.Flags = cache.Flags;
@@ -202,7 +202,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return (cmd.PrevValue, cmd.Removed);
         }
-        internal async ValueTask Clear(UntypedCache cache)
+        internal async ValueTask Clear(ICache cache)
         {
             Commands.CLEAR cmd = new Commands.CLEAR();
             cmd.Flags = cache.Flags;
@@ -212,7 +212,7 @@ namespace Infinispan.Hotrod.Core
             return;
         }
 
-        internal async ValueTask<ServerStatistics> Stats(UntypedCache cache)
+        internal async ValueTask<ServerStatistics> Stats(ICache cache)
         {
             Commands.STATS cmd = new Commands.STATS();
             cmd.Flags = cache.Flags;
@@ -221,7 +221,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.Stats;
         }
-        internal async ValueTask<(V V, Boolean Replaced)> Replace<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key, V value, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
+        internal async ValueTask<(V V, Boolean Replaced)> Replace<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key, V value, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
         {
             Commands.REPLACE<K, V> cmd = new Commands.REPLACE<K, V>(km, vm, key, value);
             cmd.Flags = cache.Flags;
@@ -238,7 +238,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return (cmd.PrevValue, cmd.Replaced);
         }
-        internal async ValueTask<Boolean> ReplaceWithVersion<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key, V value, Int64 version, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
+        internal async ValueTask<Boolean> ReplaceWithVersion<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key, V value, Int64 version, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
         {
             Commands.REPLACEWITHVERSION<K, V> cmd = new Commands.REPLACEWITHVERSION<K, V>(km, vm, key, value);
             cmd.Flags = cache.Flags;
@@ -256,7 +256,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.Replaced;
         }
-        internal async ValueTask<(V V, Boolean Removed)> RemoveWithVersion<K, V>(Marshaller<K> km, Marshaller<V> vm, UntypedCache cache, K key, Int64 version)
+        internal async ValueTask<(V V, Boolean Removed)> RemoveWithVersion<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, K key, Int64 version)
         {
             Commands.REMOVEWITHVERSION<K, V> cmd = new Commands.REMOVEWITHVERSION<K, V>(km, vm, key);
             cmd.Flags = cache.Flags;
@@ -266,7 +266,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return (cmd.PrevValue, cmd.Removed);
         }
-        internal async ValueTask<QueryResponse> Query(QueryRequest query, UntypedCache cache)
+        internal async ValueTask<QueryResponse> Query(QueryRequest query, ICache cache)
         {
             Commands.QUERY cmd = new Commands.QUERY(query);
             cmd.Flags = cache.Flags;
@@ -276,7 +276,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanException(result.Messge);
             return cmd.QueryResponse;
         }
-        internal async ValueTask<ISet<K>> KeySet<K>(Marshaller<K> km, UntypedCache cache)
+        internal async ValueTask<ISet<K>> KeySet<K>(Marshaller<K> km, ICache cache)
         {
             Commands.KEYSET<K> cmd = new Commands.KEYSET<K>(km);
             if (cache != null)
@@ -304,11 +304,11 @@ namespace Infinispan.Hotrod.Core
         // Private stuff below this line
         internal UInt32 TopologyId { get; set; } = 0xFFFFFFFFU;
         private IHostHandler HostHandler;
-        private Dictionary<UntypedCache, TopologyInfo> topologyInfoMap = new Dictionary<UntypedCache, TopologyInfo>();
+        private Dictionary<ICache, TopologyInfo> topologyInfoMap = new Dictionary<ICache, TopologyInfo>();
         private IList<InfinispanHost> mHosts = new List<InfinispanHost>();
         private InfinispanHost[] mActiveHosts = new InfinispanHost[0];
         private static Int32 MAXHASHVALUE { get; set; } = 0x7FFFFFFF;
-        private async Task<Result> Execute(UntypedCache cache, Command cmd)
+        private async Task<Result> Execute(ICache cache, Command cmd)
         {
             TopologyInfo topologyInfo;
             // Get the topology info for this cache. Initial hosts list will be used
@@ -316,7 +316,7 @@ namespace Infinispan.Hotrod.Core
             topologyInfoMap.TryGetValue(cache, out topologyInfo);
             return await ExecuteWithRetry(cache, cmd, topologyInfo);
         }
-        private async Task<Result> ExecuteWithRetry(UntypedCache cache, Command cmd, TopologyInfo topologyInfo)
+        private async Task<Result> ExecuteWithRetry(ICache cache, Command cmd, TopologyInfo topologyInfo)
         {
             InfinispanHost host;
             var hostHandlerForRetry = new HostHandlerForRetry(this);
@@ -404,7 +404,7 @@ namespace Infinispan.Hotrod.Core
         * structure to the cluster host list.
         * Needs a way to cleanup no more used hosts
         */
-        internal void UpdateTopologyInfo(TopologyInfo topology, UntypedCache cache)
+        internal void UpdateTopologyInfo(TopologyInfo topology, ICache cache)
         {
             this.TopologyId = topology.TopologyId;
             this.topologyInfoMap[cache] = topology;

--- a/src/InfinispanRequest.cs
+++ b/src/InfinispanRequest.cs
@@ -9,7 +9,7 @@ namespace Infinispan.Hotrod.Core
 {
     public class InfinispanRequest
     {
-        public InfinispanRequest(InfinispanHost host, InfinispanDG cluster, UntypedCache cache, InfinispanClient client, Command cmd, params Type[] types)
+        public InfinispanRequest(InfinispanHost host, InfinispanDG cluster, ICache cache, InfinispanClient client, Command cmd, params Type[] types)
         {
             Client = client;
             Client.TcpClient.DataReceive = OnReceive;
@@ -42,7 +42,7 @@ namespace Infinispan.Hotrod.Core
         public InfinispanHost Host { get; set; }
         public InfinispanDG Cluster { get; set; }
 
-        public UntypedCache Cache { get; set; }
+        public ICache Cache { get; set; }
         private void OnError(IClient c, ClientErrorArgs e)
         {
             if (e.Error is BeetleX.BXException || e.Error is System.Net.Sockets.SocketException ||


### PR DESCRIPTION
Intial idea was to change UntypedCache scope to internal, but C# forbids a public class to extend an internal one. While public class can implementel internal interface.
So UntypedCache has been removed and replaced with the ICache interface.

ICache has been leaved public for now.