### PR TITLE
Bysegment 28

### DIFF
--- a/Infinispan.Hotrod.Core.XUnitTest/ClusterTest.cs
+++ b/Infinispan.Hotrod.Core.XUnitTest/ClusterTest.cs
@@ -3,6 +3,8 @@ using Infinispan.Hotrod.Core.Tests.Util;
 using Xunit;
 using System;
 using System.IO;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Infinispan.Hotrod.Core.XUnitTest
 {
@@ -95,6 +97,53 @@ namespace Infinispan.Hotrod.Core.XUnitTest
             _fixture.hotRodServer1.ShutDownHotrodServer();
             Assert.Equal("valueDistributed", await _distributedCache.Get(key));
             await Assert.ThrowsAsync<InfinispanException>(() => _localCache.Get(key));
+        }
+        [Fact]
+        public async void distributedCachePutGetAllByOwner()
+        {
+            var keyVals = new Dictionary<String, String>();
+            var keys = new HashSet<String>();
+
+            for (var i = 0; i < 20; i++)
+            {
+                var k = UniqueKey.NextKey();
+                keys.Add(k);
+                keyVals.Add(k, k + "value");
+            }
+            // Getting the topology
+            var pr = await _distributedCache.Ping();
+            await _distributedCache.PutAll(keyVals);
+            var res = await _distributedCache.GetAll(keys);
+            var tasks = _distributedCache.GetAllByOwner(keys);
+            Task.WaitAll(tasks);
+            await _distributedCache.Clear();
+
+            Task.WaitAll(_distributedCache.PutAllByOwner(keyVals));
+            var res1 = await _distributedCache.GetAll(keys);
+            var tasks1 = _distributedCache.GetAllByOwner(keys);
+            Task.WaitAll(tasks1);
+
+
+            var d = new Dictionary<string, string>();
+            foreach (var t in tasks)
+            {
+                foreach (var entry in t.Result)
+                {
+                    d.Add(entry.Key, entry.Value);
+                }
+            }
+            Assert.Equal(d, res);
+
+            var d1 = new Dictionary<string, string>();
+            foreach (var t in tasks1)
+            {
+                foreach (var entry in t.Result)
+                {
+                    d1.Add(entry.Key, entry.Value);
+                }
+            }
+            Assert.Equal(d1, res1);
+            Assert.Equal(d, d1);
         }
     }
 }

--- a/Infinispan.Hotrod.Core.XUnitTest/ClusterTest.cs
+++ b/Infinispan.Hotrod.Core.XUnitTest/ClusterTest.cs
@@ -115,13 +115,27 @@ namespace Infinispan.Hotrod.Core.XUnitTest
             await _distributedCache.PutAll(keyVals);
             var res = await _distributedCache.GetAll(keys);
             var tasks = _distributedCache.GetAllByOwner(keys);
-            Task.WaitAll(tasks);
+            try
+            {
+                Task.WaitAll(tasks);
+            }
+            catch (AggregateException aEx)
+            {
+                Assert.Null("Should not reach this point: " + aEx.Message);
+            }
             await _distributedCache.Clear();
 
             Task.WaitAll(_distributedCache.PutAllByOwner(keyVals));
             var res1 = await _distributedCache.GetAll(keys);
             var tasks1 = _distributedCache.GetAllByOwner(keys);
-            Task.WaitAll(tasks1);
+            try
+            {
+                Task.WaitAll(tasks1);
+            }
+            catch (AggregateException aEx)
+            {
+                Assert.Null("Should not reach this point: " + aEx.Message);
+            }
 
 
             var d = new Dictionary<string, string>();

--- a/Infinispan.Hotrod.Core.XUnitTest/DefaultCacheTest.cs
+++ b/Infinispan.Hotrod.Core.XUnitTest/DefaultCacheTest.cs
@@ -348,26 +348,19 @@ namespace Infinispan.Hotrod.Core.XUnitTest
             ISet<String> keySet = new HashSet<String>();
             keySet.Add(key1);
             keySet.Add(key2);
-            var tasks = _cache.GetAllByOwner(keySet);
+            var partResult = _cache.GetAllPart(keySet);
             // Skip this if there's no topology
-            if (tasks == null)
+            if (partResult == null)
                 return;
             try
             {
-                Task.WaitAll(tasks);
+                partResult.WaitAll();
             }
             catch (AggregateException aex)
             {
                 Assert.Null(aex);
             }
-            var d = new Dictionary<string, string>();
-            foreach (var t in tasks)
-            {
-                foreach (var e in t.Result)
-                {
-                    d.Add(e.Key, e.Value);
-                }
-            }
+            var d = partResult.Result();
             Assert.Equal(d[key1], await _cache.Get(key1));
             Assert.Equal(d[key2], await _cache.Get(key2));
             Assert.Equal("carbon", d[key1]);

--- a/Infinispan.Hotrod.Core.XUnitTest/DefaultCacheTest.cs
+++ b/Infinispan.Hotrod.Core.XUnitTest/DefaultCacheTest.cs
@@ -374,6 +374,13 @@ namespace Infinispan.Hotrod.Core.XUnitTest
             Assert.Equal("oxygen", d[key2]);
         }
 
+        [Fact]
+        public async void pingTest()
+        {
+            var result = await _cache.Ping();
+            Assert.NotNull(result);
+        }
+
         // [Test]
         // public void GetBulkTest()
         // {

--- a/src/Cache.cs
+++ b/src/Cache.cs
@@ -175,6 +175,12 @@ namespace Infinispan.Hotrod.Core
         {
             return Cluster.SplitBySegment<K>(KeyMarshaller, this, keys);
         }
+
+        public async Task<PingResult> Ping()
+        {
+            return await Cluster.Ping(this);
+        }
+
         private static List<Object> unwrapWithProjection(QueryResponse resp)
         {
             List<Object> result = new List<Object>();
@@ -350,5 +356,14 @@ namespace Infinispan.Hotrod.Core
         }
         private IDictionary<String, String> stats;
     }
+    public class PingResult
+    {
+        public MediaType KeyType;
+        public MediaType ValueType;
+        public int Version;
+        public int[] Operations;
+
+    }
+
 
 }

--- a/src/Cache.cs
+++ b/src/Cache.cs
@@ -163,6 +163,18 @@ namespace Infinispan.Hotrod.Core
         {
             return await Cluster.GetAll(KeyMarshaller, ValueMarshaller, this, keys);
         }
+        public Task<IDictionary<K, V>>[] GetAllByOwner(ISet<K> keys)
+        {
+            return Cluster.GetAllByOwner(KeyMarshaller, ValueMarshaller, this, keys);
+        }
+        public Task[] PutAllByOwner(IDictionary<K, V> map, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
+        {
+            return Cluster.PutAllByOwner(KeyMarshaller, ValueMarshaller, this, map, lifespan, maxidle);
+        }
+        public IDictionary<int, ISet<K>> SplitBySegment(ISet<K> keys)
+        {
+            return Cluster.SplitBySegment<K>(KeyMarshaller, this, keys);
+        }
         private static List<Object> unwrapWithProjection(QueryResponse resp)
         {
             List<Object> result = new List<Object>();

--- a/src/InfinispanCommands/GET_ALL.cs
+++ b/src/InfinispanCommands/GET_ALL.cs
@@ -14,9 +14,9 @@ namespace Infinispan.Hotrod.Core.Commands
             Keys = keys;
             NetworkReceive = OnReceive;
         }
-        public Marshaller<V> ValueMarshaller;
         public Marshaller<K> KeyMarshaller;
-
+        public Marshaller<V> ValueMarshaller;
+        public int Segment = -1;
         public ISet<K> Keys { get; set; }
 
         public IDictionary<K, V> Entries;
@@ -59,6 +59,15 @@ namespace Infinispan.Hotrod.Core.Commands
             }
             return new Result { Status = ResultStatus.Completed, ResultType = ResultType.Null };
         }
+        internal override TopologyKnoledge getTopologyKnowledgeType()
+        {
+            return TopologyKnoledge.SEGMENT;
+        }
+        internal override int getSegment()
+        {
+            return Segment;
+        }
+
 
     }
 }

--- a/src/InfinispanCommands/PING.cs
+++ b/src/InfinispanCommands/PING.cs
@@ -1,0 +1,48 @@
+﻿using BeetleX.Buffers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Infinispan.Hotrod.Core.Commands
+{
+    public class PING : Command
+    {
+        public PING()
+        {
+            NetworkReceive = OnReceive;
+        }
+        public override string Name => "PING";
+
+        public override Byte Code => 0x17;
+
+        public PingResult Result;
+
+        public override void OnExecute(CommandContext ctx)
+        {
+            base.OnExecute(ctx);
+        }
+
+        public override void Execute(CommandContext ctx, InfinispanClient client, PipeStream stream)
+        {
+            base.Execute(ctx, client, stream);
+        }
+        public override Result OnReceive(InfinispanRequest request, PipeStream stream)
+        {
+            if (request.ResponseStatus == Codec30.NO_ERROR_STATUS)
+            {
+                this.Result = new PingResult();
+                this.Result.KeyType = Codec.readMediaType(stream);
+                this.Result.ValueType = Codec.readMediaType(stream);
+                this.Result.Version = stream.ReadByte();
+                var numOps = Codec.readVInt(stream);
+                this.Result.Operations = new int[numOps];
+                for (var i = 0; i < numOps; i++)
+                {
+                    this.Result.Operations[i] = Codec.readShort(stream);
+                }
+                return new Result { Status = ResultStatus.Completed, ResultType = ResultType.Object };
+            }
+            return new Result { Status = ResultStatus.Completed, ResultType = ResultType.Error };
+        }
+    }
+}

--- a/src/InfinispanCommands/PUT_ALL.cs
+++ b/src/InfinispanCommands/PUT_ALL.cs
@@ -7,7 +7,7 @@ namespace Infinispan.Hotrod.Core.Commands
 {
     public class PUT_ALL<K, V> : Command
     {
-        public PUT_ALL(Marshaller<K> km, Marshaller<V> vm, Dictionary<K, V> map)
+        public PUT_ALL(Marshaller<K> km, Marshaller<V> vm, IDictionary<K, V> map)
         {
             Map = map;
             KeyMarshaller = km;
@@ -17,6 +17,7 @@ namespace Infinispan.Hotrod.Core.Commands
         }
         public Marshaller<K> KeyMarshaller;
         public Marshaller<V> ValueMarshaller;
+        public int Segment = -1;
         public int TimeOut { get; set; }
 
         public ExpirationTime Lifespan = new ExpirationTime { Unit = TimeUnit.DEFAULT, Value = 0 };
@@ -26,7 +27,7 @@ namespace Infinispan.Hotrod.Core.Commands
 
         public override Byte Code => 0x2D;
 
-        public Dictionary<K, V> Map { get; set; }
+        public IDictionary<K, V> Map { get; set; }
         public V PrevValue { get; set; }
 
         public override void OnExecute(CommandContext ctx)

--- a/src/InfinispanDG.cs
+++ b/src/InfinispanDG.cs
@@ -388,7 +388,7 @@ namespace Infinispan.Hotrod.Core
                 throw new InfinispanOperationException<ISet<K>>(keys, result.Messge);
             return cmd.Entries;
         }
-        internal Task[] PutAllByOwner<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, IDictionary<K, V> map, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
+        internal Task[] PutAllPart<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, IDictionary<K, V> map, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
         {
             var mapBySeg = this.SplitKeyValueBySegment(km, cache, map);
             Task[] ts = new Task[mapBySeg.Count];
@@ -402,7 +402,7 @@ namespace Infinispan.Hotrod.Core
             }
             return ts;
         }
-        internal Task<IDictionary<K, V>>[] GetAllByOwner<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, ISet<K> keys)
+        internal Task<IDictionary<K, V>>[] GetAllPart<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, ISet<K> keys)
         {
             var map = this.SplitBySegment(km, cache, keys);
             if (map == null)

--- a/src/InfinispanDG.cs
+++ b/src/InfinispanDG.cs
@@ -391,7 +391,7 @@ namespace Infinispan.Hotrod.Core
         internal Task[] PutAllByOwner<K, V>(Marshaller<K> km, Marshaller<V> vm, ICache cache, IDictionary<K, V> map, ExpirationTime lifespan = null, ExpirationTime maxidle = null)
         {
             var mapBySeg = this.SplitKeyValueBySegment(km, cache, map);
-            Task[] ts = new Task<IDictionary<K, V>>[map.Count];
+            Task[] ts = new Task[mapBySeg.Count];
             int i = 0;
             foreach (var entry in mapBySeg)
             {

--- a/src/InfinispanDG.cs
+++ b/src/InfinispanDG.cs
@@ -472,11 +472,8 @@ namespace Infinispan.Hotrod.Core
 
         // Private stuff below this line
         internal UInt32 TopologyId { get; set; } = 0xFFFFFFFFU;
-        private IHostHandler HostHandler;
         private Dictionary<ICache, TopologyInfo> topologyInfoMap = new Dictionary<ICache, TopologyInfo>();
-
         private IDictionary<string, Cluster> mClusters = new Dictionary<string, Cluster>();
-
         internal string mActiveCluster = "DEFAULT_CLUSTER";
         private InfinispanHost[] mActiveHosts = new InfinispanHost[0];
         private static Int32 MAXHASHVALUE { get; set; } = 0x7FFFFFFF;

--- a/src/InfinispanDG.cs
+++ b/src/InfinispanDG.cs
@@ -418,6 +418,16 @@ namespace Infinispan.Hotrod.Core
             }
             return ts;
         }
+        internal async ValueTask<PingResult> Ping(ICache cache)
+        {
+            Commands.PING cmd = new Commands.PING();
+            cmd.Flags = cache.Flags;
+            var result = await Execute(cache, cmd);
+            if (result.IsError)
+                throw new InfinispanException(result.Messge);
+            return cmd.Result;
+        }
+
         public IDictionary<int, ISet<K>> SplitBySegment<K>(Marshaller<K> km, ICache cache, ICollection<K> keys)
         {
             TopologyInfo topologyInfo;

--- a/src/InfinispanException.cs
+++ b/src/InfinispanException.cs
@@ -11,4 +11,16 @@ namespace Infinispan.Hotrod.Core
         }
         public InfinispanException(string msg, Exception innerError) : base(msg, innerError) { }
     }
+    public class InfinispanOperationException<K> : InfinispanException
+    {
+        public K Args;
+        public InfinispanOperationException(K args, string msg) : base(msg)
+        {
+            Args = args;
+        }
+        public InfinispanOperationException(K args, string msg, Exception innerError) : base(msg, innerError)
+        {
+            Args = args;
+        }
+    }
 }


### PR DESCRIPTION
GetAllPart, PutAllPart implementation. Fixes #28 
Ping operation implementation. Fixes #29 

Input keys are partition by segment owner and a set of operations is build and sent in parallel to each owner.
An IPartResult object is returned and the user can call the WaitAll method on it. 

Result (available only for the GetAllPart operation) is returned merged calling the method Result(). Exceptions are returned as InfinispanOperationException, containing the failed partition of keyset, and grouped as AggregateException.
A common workflow of execution is:
```
            var resultPart = _distributedCache.GetAllPart(keys);
            try
            {
                resultPart.WaitAll();
            }
            catch (AggregateException aEx)
            {
                // Handle here exception. Access failed keys partition as:
                // ((InfinispanOperationException<ISet<string>>)aEx.InnerExceptions[0,1,2,3...]).Args
            }
            // Merge the partitioned results
            var opResult = resultPart.Result();  // key,val dictionary
```
