### PR TITLE
Report more info to the used in case of error

### DIFF
--- a/.github/workflows/doxygen-ghpages.yml
+++ b/.github/workflows/doxygen-ghpages.yml
@@ -5,10 +5,15 @@ on: [push, pull_request]
 jobs:
   run-ci-tests:
     runs-on: ubuntu-latest
+    env:
+       HAVE_DOTNET_TOKEN: ${{ secrets.DOTNETCLIENT_PERSONAL_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v2
+        if: ${{ env.HAVE_DOTNET_TOKEN == 'true' }}
       - uses: mattnotmitt/doxygen-action@v1.9.2
+        if: ${{ env.HAVE_DOTNET_TOKEN == 'true' }}
       - uses: peaceiris/actions-gh-pages@v3
+        if: ${{ env.HAVE_DOTNET_TOKEN == 'true' }}
         with:
           personal_token: ${{ secrets.DOTNETCLIENT_PERSONAL_TOKEN }}
           publish_dir: ./docs

--- a/src/Infinispan.Hotrod.Core.csproj
+++ b/src/Infinispan.Hotrod.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReleaseNotes />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BeetleX" Version="1.6.8" />
+    <PackageReference Include="BeetleX" Version="1.8.0.3" />
     <PackageReference Include="Google.Protobuf" Version="3.19.1" />
     <PackageReference Include="Grpc.Tools" Version="2.41.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,7 +23,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="protobuf-net" Version="2.4.6" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="Protos/query.proto"></Protobuf>

--- a/src/InfinispanException.cs
+++ b/src/InfinispanException.cs
@@ -4,23 +4,18 @@ using System.Text;
 
 namespace Infinispan.Hotrod.Core
 {
+    /// <summary>
+    /// InfinispanException represent a generic exception
+    /// </summary>
     public class InfinispanException : Exception
     {
-        public InfinispanException(string msg) : base(msg)
+        /// <summary>
+        /// CommandResult collect all the info related to the command execution
+        /// </summary>
+        public CommandResult Result;
+        public InfinispanException(CommandResult result) : base(result.ErrorMessage)
         {
-        }
-        public InfinispanException(string msg, Exception innerError) : base(msg, innerError) { }
-    }
-    public class InfinispanOperationException<K> : InfinispanException
-    {
-        public K Args;
-        public InfinispanOperationException(K args, string msg) : base(msg)
-        {
-            Args = args;
-        }
-        public InfinispanOperationException(K args, string msg, Exception innerError) : base(msg, innerError)
-        {
-            Args = args;
+            Result = result;
         }
     }
 }

--- a/src/InfinispanResult.cs
+++ b/src/InfinispanResult.cs
@@ -6,27 +6,11 @@ namespace Infinispan.Hotrod.Core
 {
     public class Result
     {
-        public List<ResultItem> Data { get; set; } = new List<ResultItem>();
-
         public string Messge { get; set; }
 
         public ResultStatus Status { get; set; } = ResultStatus.None;
 
         public ResultType ResultType { get; internal set; }
-
-        internal int ArrayCount { get; set; }
-
-        internal int ReadCount { get; set; }
-
-        internal int ArrayReadCount { get; set; }
-
-        internal int? BodyLength { get; set; }
-
-        public void Throw()
-        {
-            if (IsError)
-                throw new InfinispanException(Messge);
-        }
 
         public bool IsError
         {
@@ -37,30 +21,23 @@ namespace Infinispan.Hotrod.Core
                      || this.ResultType == ResultType.NetError);
             }
         }
-
-        public object Value
-        {
-            get
-            {
-                if (Data.Count > 0)
-                    return Data[0].Data;
-                return Messge;
-            }
-        }
-
     }
-
-    public class ResultItem
+    /// <summary>
+    /// CommandResult represent all the info related to a command execution
+    /// </summary>
+    public class CommandResult
     {
-        public object Data { get; set; }
-
-        public ResultType Type { get; set; }
-
-        public override string ToString()
-        {
-            return $"{Type}:{Data}";
-        }
+        /// <summary>
+        /// Results contains all the messages related to execution.
+        /// </summary>
+        public List<Result> Results = new List<Result>();
+        /// <summary>
+        /// IsError is true if the final status of the command is not executed due to error.
+        /// </summary>
+        internal bool IsError = false;
+        /// <summary>
+        /// ErrorMessage is the error related to the failure of the command.
+        /// </summary>
+        public string ErrorMessage;
     }
-
-
 }


### PR DESCRIPTION
Report more info to the user in case of error.
Additional fields have been added to the  `InfinispanException` class.
- a collection of `Result`, since a single command could have several result associated: retry or different hosts involved due topology...
- an `ErrorMessage` string, with some info on the failure.